### PR TITLE
Update gate.js

### DIFF
--- a/gate.js
+++ b/gate.js
@@ -57,8 +57,8 @@ module.exports = function(RED) {
             context.get('state',storeName,function(err,state) {
                 if (err) {
                     node.error('message error reading from context store: ' + storeName)
-                } else if (typeof msg.topic === 'string' && 
-                        msg.topic.toLowerCase() === node.controlTopic) { // change state
+                } else if (typeof msg.control === 'string' && 
+                        msg.control.toLowerCase() === node.controlTopic) { // change state
                     if (typeof msg.payload === 'undefined' || msg.payload === null) {
                         msg.payload = '';
                     }


### PR DESCRIPTION
Instead of requiring the control message to be the topic, I'm wondering if it could be more generic and changed to `message.control`. That way, you can still preserve data that might be in the message topic as well as control the gate. I think would be a major breaking change though. Perhaps there is a way to listen for both? This is the first time I've ever done anything on github, so while I watched a few YouTube videos about it, please forgive me if I'm doing something terribly wrong. I wanted to try to test it myself, but I don't know how to create an updated npm package to import into NR. 